### PR TITLE
Data Structure: Add Hash table

### DIFF
--- a/clang-format
+++ b/clang-format
@@ -1,0 +1,5 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+BreakBeforeBraces: WebKit
+Cpp11BracedListStyle: false
+IndentCaseLabels: true

--- a/include/cds/hash_table.h
+++ b/include/cds/hash_table.h
@@ -1,5 +1,5 @@
-#ifndef CDS_HASH_TABLE.H
-#define CDS_HASH_TABLE .H
+#ifndef CDS_HASH_TABLE_H
+#define CDS_HASH_TABLE_H
 
 #include <stddef.h>
 
@@ -43,4 +43,4 @@ int ht_compare_int(const void *key1, const void *key2);
 size_t ht_hash_float(const void *key);
 int ht_compare_float(const void *key1, const void *key2);
 
-#endif
+#endif // CDS_HASH_TABLE_H

--- a/include/cds/hash_table.h
+++ b/include/cds/hash_table.h
@@ -33,4 +33,14 @@ void *ht_search(HashTable *table, const void *key);
  */
 int ht_delete(HashTable *table, const void *key);
 
+/* Convenience Functions */
+size_t ht_hash_string(const void *key);
+int ht_compare_string(const void *key1, const void *key2);
+
+size_t ht_hash_int(const void *key);
+int ht_compare_int(const void *key1, const void *key2);
+
+size_t ht_hash_float(const void *key);
+int ht_compare_float(const void *key1, const void *key2);
+
 #endif

--- a/include/cds/hash_table.h
+++ b/include/cds/hash_table.h
@@ -8,4 +8,29 @@ typedef struct HashTable HashTable;
 typedef size_t (*HashFunction)(const void *key);
 typedef int (*CompareFunction)(const void *key1, const void *key2);
 
+/** Creates a new empty hash table */
+HashTable *ht_create(size_t capacity, HashFunction hash_fn, CompareFunction comp_fn);
+
+/** Destroys and frees memory from a hash table */
+void ht_destroy(HashTable *table);
+
+/**
+ * Inserts a key-value pair.
+ * If the key already exists, the value is updated.
+ * Returns 0 on success, non-zero on failure.
+ */
+int ht_insert(HashTable *table, void *key, void *value);
+
+/**
+ * Searches for a key.
+ * Returns the associated value if found, or NULL if not found.
+ */
+void *ht_search(HashTable *table, const void *key);
+
+/**
+ * Deletes a key-value pair.
+ * Returns 0 on success, non-zero if the key was not found.
+ */
+int ht_delete(HashTable *table, const void *key);
+
 #endif

--- a/include/cds/hash_table.h
+++ b/include/cds/hash_table.h
@@ -1,0 +1,11 @@
+#ifndef CDS_HASH_TABLE.H
+#define CDS_HASH_TABLE .H
+
+#include <stddef.h>
+
+typedef struct HashTable HashTable;
+
+typedef size_t (*HashFunction)(const void *key);
+typedef int (*CompareFunction)(const void *key1, const void *key2);
+
+#endif

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -140,7 +140,18 @@ void *ht_search(HashTable *table, const void *key)
  * Deletes a key-value pair.
  * Returns 0 on success, non-zero if the key was not found.
  */
-int ht_delete(HashTable *table, const void *key);
+int ht_delete(HashTable *table, const void *key)
+{
+    HashTableEntry *entry;
+    entry = ht_find_slot(table, key, NULL);
+
+    if (entry->state == SLOT_OCCUPIED)
+    {
+        entry->state == SLOT_DELETED;
+        return 0;
+    }
+    return -1;
+}
 
 /* Convenience Functions */
 size_t ht_hash_string(const void *key);

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -71,7 +71,16 @@ typedef size_t (*HashFunction)(const void *key);
 typedef int (*CompareFunction)(const void *key1, const void *key2);
 
 /** Creates a new empty hash table */
-HashTable *ht_create(size_t capacity, HashFunction hash_fn, CompareFunction comp_fn);
+HashTable *ht_create(size_t capacity, HashFunction hash_fn, CompareFunction comp_fn)
+{
+    HashTable *table = malloc(sizeof(HashTable));
+    table->capacity = capacity;
+    table->hash_fn = hash_fn;
+    table->comp_fn = comp_fn;
+    table->size = 0;
+    table->entries = calloc(capacity, sizeof(HashTableEntry));
+    return table;
+}
 
 /** Destroys and frees memory from a hash table */
 void ht_destroy(HashTable *table);

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -5,3 +5,68 @@
 #include <math.h>
 
 #define MAX_LOAD_FACTOR 0.7
+
+/* ENUMS */
+typedef enum
+{
+    SLOT_EMPTY,
+    SLOT_OCCUPIED,
+    SLOT_DELETED // tombstone
+} SlotState;
+
+/* STRUCTS */
+typedef struct
+{
+    void *key;
+    void *value;
+    SlotState state;
+} HashTableEntry;
+
+struct HashTable
+{
+    size_t capacity; // Total num of slots
+    size_t size;     // Num of occupied slots
+
+    HashFunction hash_fn;
+    CompareFunction comp_fn;
+
+    HashTableEntry *entries; // Array of slots
+};
+
+typedef size_t (*HashFunction)(const void *key);
+typedef int (*CompareFunction)(const void *key1, const void *key2);
+
+/** Creates a new empty hash table */
+HashTable *ht_create(size_t capacity, HashFunction hash_fn, CompareFunction comp_fn);
+
+/** Destroys and frees memory from a hash table */
+void ht_destroy(HashTable *table);
+
+/**
+ * Inserts a key-value pair.
+ * If the key already exists, the value is updated.
+ * Returns 0 on success, non-zero on failure.
+ */
+int ht_insert(HashTable *table, void *key, void *value);
+
+/**
+ * Searches for a key.
+ * Returns the associated value if found, or NULL if not found.
+ */
+void *ht_search(HashTable *table, const void *key);
+
+/**
+ * Deletes a key-value pair.
+ * Returns 0 on success, non-zero if the key was not found.
+ */
+int ht_delete(HashTable *table, const void *key);
+
+/* Convenience Functions */
+size_t ht_hash_string(const void *key);
+int ht_compare_string(const void *key1, const void *key2);
+
+size_t ht_hash_int(const void *key);
+int ht_compare_int(const void *key1, const void *key2);
+
+size_t ht_hash_float(const void *key);
+int ht_compare_float(const void *key1, const void *key2);

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -83,7 +83,12 @@ HashTable *ht_create(size_t capacity, HashFunction hash_fn, CompareFunction comp
 }
 
 /** Destroys and frees memory from a hash table */
-void ht_destroy(HashTable *table);
+void ht_destroy(HashTable *table)
+{
+    // expect users to free their own keys/values
+    free(table->entries);
+    free(table);
+}
 
 /**
  * Inserts a key-value pair.

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -124,7 +124,17 @@ int ht_insert(HashTable *table, void *key, void *value)
  * Searches for a key.
  * Returns the associated value if found, or NULL if not found.
  */
-void *ht_search(HashTable *table, const void *key);
+void *ht_search(HashTable *table, const void *key)
+{
+    HashTableEntry *entry;
+    entry = ht_find_slot(table, key, NULL);
+
+    if (entry != NULL && entry->state == SLOT_OCCUPIED)
+    {
+        return entry->value;
+    }
+    return NULL;
+}
 
 /**
  * Deletes a key-value pair.

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -95,7 +95,30 @@ void ht_destroy(HashTable *table)
  * If the key already exists, the value is updated.
  * Returns 0 on success, non-zero on failure.
  */
-int ht_insert(HashTable *table, void *key, void *value);
+int ht_insert(HashTable *table, void *key, void *value)
+{
+    HashTableEntry *entry;
+    HashTableEntry **p_first_tombstone;
+    entry = ht_find_slot(table, key, p_first_tombstone);
+    if (entry->state == SLOT_OCCUPIED)
+    {
+        entry->value = value;
+        return 0;
+    }
+    else if (entry->state == SLOT_EMPTY || entry->state == SLOT_DELETED)
+    {
+        if (*p_first_tombstone != NULL)
+        {
+            (*p_first_tombstone)->state = SLOT_OCCUPIED;
+            (*p_first_tombstone)->value = value;
+            return 0;
+        }
+        entry->state = SLOT_OCCUPIED;
+        entry->value = value;
+        return 0;
+    }
+    return -1;
+}
 
 /**
  * Searches for a key.

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -3,3 +3,5 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+
+#define MAX_LOAD_FACTOR 0.7

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -37,6 +37,10 @@ struct HashTable
 // Idea: just a workhorse func that searches for key in entry list. Returns pointer to a slot
 static HashTableEntry *ht_find_slot(HashTable *table, const void *key, HashTableEntry **first_tombstone)
 {
+    if (table == NULL || key == NULL)
+    {
+        return -1;
+    }
     size_t hash = table->hash_fn(key);
     // go through entries
     for (size_t i = 0; i < table->capacity; ++i)
@@ -70,7 +74,18 @@ static HashTableEntry *ht_find_slot(HashTable *table, const void *key, HashTable
 
 static int ht_resize(HashTable *table, const size_t new_capacity)
 {
+    if (table == NULL)
+    {
+        return -1;
+    }
+
     HashTableEntry *new_entries = calloc(new_capacity, sizeof(HashTableEntry));
+
+    if (new_entries == NULL)
+    {
+        return -1;
+    }
+
     HashTableEntry *old_entries = table->entries;
     size_t *old_capacity = table->capacity;
 
@@ -95,18 +110,36 @@ static int ht_resize(HashTable *table, const size_t new_capacity)
 /** Creates a new empty hash table */
 HashTable *ht_create(size_t capacity, HashFunction hash_fn, CompareFunction comp_fn)
 {
+    if (capacity == 0 || hash_fn == NULL || comp_fn == NULL)
+    {
+        return NULL;
+    }
+
     HashTable *table = malloc(sizeof(HashTable));
+    if (table == NULL)
+    {
+        return NULL;
+    }
     table->capacity = capacity;
     table->hash_fn = hash_fn;
     table->comp_fn = comp_fn;
     table->size = 0;
     table->entries = calloc(capacity, sizeof(HashTableEntry));
+    if (table->entries == NULL)
+    {
+        return NULL;
+    }
+
     return table;
 }
 
 /** Destroys and frees memory from a hash table */
 void ht_destroy(HashTable *table)
 {
+    if (table == NULL)
+    {
+        return;
+    }
     // expect users to free their own keys/values
     free(table->entries);
     free(table);
@@ -119,9 +152,17 @@ void ht_destroy(HashTable *table)
  */
 int ht_insert(HashTable *table, void *key, void *value)
 {
+    if (table == NULL || key == NULL)
+    {
+        return -1;
+    }
+
     if (table->size >= table->capacity * MAX_LOAD_FACTOR)
     {
-        ht_resize(table, table->capacity * 2);
+        if (!ht_resize(table, table->capacity * 2))
+        {
+            return -1;
+        }
     }
 
     HashTableEntry *entry;
@@ -155,6 +196,11 @@ int ht_insert(HashTable *table, void *key, void *value)
  */
 void *ht_search(HashTable *table, const void *key)
 {
+    if (table == NULL || key == NULL)
+    {
+        return NULL;
+    }
+
     HashTableEntry *entry;
     entry = ht_find_slot(table, key, NULL);
 
@@ -171,6 +217,11 @@ void *ht_search(HashTable *table, const void *key)
  */
 int ht_delete(HashTable *table, const void *key)
 {
+    if (table == NULL || key == NULL)
+    {
+        return -1;
+    }
+
     HashTableEntry *entry;
     entry = ht_find_slot(table, key, NULL);
 

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -33,6 +33,16 @@ struct HashTable
     HashTableEntry *entries; // Array of slots
 };
 
+/* PRIVATE FUNCTIONS */
+// Idea: just a workhorse func that searches for key in entry list. Returns pointer to a slot
+static HashTableEntry *ht_find_slot(HashTable *table, const void *key, HashTableEntry **p_first_tombstone)
+{
+    // go through entries
+    // if we're searching, we just look for matching key and return either slot (if found) or NULL/empty
+    // if we're deleting, same thing. In the delete func, we set the status to deleted
+    // if inserting, same thing but we store any passing tombstones. In insert func, we insert into either first tombstone or empty
+}
+
 typedef size_t (*HashFunction)(const void *key);
 typedef int (*CompareFunction)(const void *key1, const void *key2);
 

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -145,7 +145,7 @@ int ht_delete(HashTable *table, const void *key)
     HashTableEntry *entry;
     entry = ht_find_slot(table, key, NULL);
 
-    if (entry->state == SLOT_OCCUPIED)
+    if (entry != NULL && entry->state == SLOT_OCCUPIED)
     {
         entry->state == SLOT_DELETED;
         return 0;

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -39,7 +39,7 @@ static HashTableEntry *ht_find_slot(HashTable *table, const void *key, HashTable
 {
     if (table == NULL || key == NULL)
     {
-        return -1;
+        return NULL;
     }
     size_t hash = table->hash_fn(key);
     // go through entries
@@ -87,7 +87,7 @@ static int ht_resize(HashTable *table, const size_t new_capacity)
     }
 
     HashTableEntry *old_entries = table->entries;
-    size_t *old_capacity = table->capacity;
+    size_t old_capacity = table->capacity;
 
     table->entries = new_entries;
     table->capacity = new_capacity;
@@ -98,7 +98,6 @@ static int ht_resize(HashTable *table, const size_t new_capacity)
         if (old_entries[i].state == SLOT_OCCUPIED)
         {
             ht_insert(table, old_entries[i].key, old_entries[i].value);
-            table->size++;
         }
     }
     free(old_entries);
@@ -159,7 +158,7 @@ int ht_insert(HashTable *table, void *key, void *value)
 
     if (table->size >= table->capacity * MAX_LOAD_FACTOR)
     {
-        if (!ht_resize(table, table->capacity * 2))
+        if (ht_resize(table, table->capacity * 2) != 0)
         {
             return -1;
         }

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -154,11 +154,35 @@ int ht_delete(HashTable *table, const void *key)
 }
 
 /* Convenience Functions */
-size_t ht_hash_string(const void *key);
-int ht_compare_string(const void *key1, const void *key2);
+size_t ht_hash_string(const void *key)
+{
+    // djb2 hash alg
+    unsigned long hash = 5381;
+    int c;
+    const unsigned char *str = (const unsigned char *)key;
+    while (c = *str++)
+        hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
 
-size_t ht_hash_int(const void *key);
-int ht_compare_int(const void *key1, const void *key2);
+    return hash;
+}
+int ht_compare_string(const void *key1, const void *key2)
+{
+    return strcmp((const char *)key1, (const char *)key2);
+}
 
-size_t ht_hash_float(const void *key);
-int ht_compare_float(const void *key1, const void *key2);
+size_t ht_hash_int(const void *key)
+{
+    int int_key = *(const int *)key;
+    // placeholder hash based on FNV-1a - consider murmur later
+    return (size_t)int_key * 2654435761u;
+}
+int ht_compare_int(const void *key1, const void *key2)
+{
+    int int1 = *(const int *)key1;
+    int int2 = *(const int *)key2;
+    return int1 - int2;
+}
+
+// floats are annoying for now
+// size_t ht_hash_float(const void *key);
+// int ht_compare_float(const void *key1, const void *key2);

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -1,0 +1,5 @@
+#include "cds/hash_table.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -37,10 +37,34 @@ struct HashTable
 // Idea: just a workhorse func that searches for key in entry list. Returns pointer to a slot
 static HashTableEntry *ht_find_slot(HashTable *table, const void *key, HashTableEntry **p_first_tombstone)
 {
+    size_t hash = table->hash_fn(key);
     // go through entries
-    // if we're searching, we just look for matching key and return either slot (if found) or NULL/empty
-    // if we're deleting, same thing. In the delete func, we set the status to deleted
-    // if inserting, same thing but we store any passing tombstones. In insert func, we insert into either first tombstone or empty
+    for (size_t i = 0; i < table->capacity; ++i)
+    {
+        // i*i is simplest quadratic probe
+        size_t index = (hash + i * i) % table->capacity;
+        HashTableEntry *entry = &table->entries[index];
+
+        if (entry->state == SLOT_OCCUPIED)
+        {
+            // if we're searching, we just look for matching key and return either slot (if found) or NULL/empty
+            // if we're deleting, same thing. In the delete func, we set the status to deleted
+            if (table->comp_fn(entry->key, key) == 0)
+            {
+                return entry;
+            }
+        }
+        else if (entry->state == SLOT_DELETED)
+        {
+            // if inserting, same thing but we store any passing tombstones. In insert func, we insert into either first tombstone or empty
+            if (p_first_tombstone != NULL && *p_first_tombstone == NULL)
+                *p_first_tombstone = entry;
+        }
+        else if (entry->state == SLOT_EMPTY)
+        {
+            return entry;
+        }
+    }
 }
 
 typedef size_t (*HashFunction)(const void *key);

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -68,9 +68,6 @@ static HashTableEntry *ht_find_slot(HashTable *table, const void *key, HashTable
     return NULL;
 }
 
-typedef size_t (*HashFunction)(const void *key);
-typedef int (*CompareFunction)(const void *key1, const void *key2);
-
 /** Creates a new empty hash table */
 HashTable *ht_create(size_t capacity, HashFunction hash_fn, CompareFunction comp_fn)
 {

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -147,6 +147,7 @@ int ht_delete(HashTable *table, const void *key)
     if (entry != NULL && entry->state == SLOT_OCCUPIED)
     {
         entry->state = SLOT_DELETED;
+        table->size--;
         return 0;
     }
     return -1;

--- a/tests/test_hash_table.c
+++ b/tests/test_hash_table.c
@@ -1,0 +1,21 @@
+#include "cds/hash_table.h"
+
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+int main()
+{
+    // String test
+    HashTable *table = ht_create(10, ht_hash_string, ht_compare_string);
+    assert(table != NULL);
+
+    ht_insert(table, "name", "Sky");
+
+    void *name = ht_search(table, "name");
+    assert(name != NULL);
+    assert(strcmp(name, "Sky") == 0);
+
+    printf("Tests passed!\n");
+    return 0;
+}


### PR DESCRIPTION
Adds simple implementation of open-addressed quadratic-probe hash table. Generic typing but requires user to provide relevant hashing and comparison functions for the data types. Basic convenience functions provided.

Uses simplified FNV-1a hash for ints and djb2 for strings. Will need to be updated to murmur later.

Also worth creating another hash function with linear probing and SIMD-based lookup support later.